### PR TITLE
Remove null warning

### DIFF
--- a/src/com/winterwell/es/client/ESHttpResponse.java
+++ b/src/com/winterwell/es/client/ESHttpResponse.java
@@ -147,7 +147,6 @@ public class ESHttpResponse implements IESResponse, SearchResponse, BulkResponse
 		if ( ! isSuccess()) {			
 			return true;
 		}
-		Log.w("ES", error);
 		Map<String, Object> map = getParsedJson();
 		Object fails = map.get("errors"); // TODO Out of date?!
 		if (Utils.yes(fails)) {


### PR DESCRIPTION
We were logging the contents of the field `error` immediately after testing that it must be null.