### PR TITLE
Set '{}' body for Create Index requests

### DIFF
--- a/src/com/winterwell/es/client/admin/CreateIndexRequest.java
+++ b/src/com/winterwell/es/client/admin/CreateIndexRequest.java
@@ -23,6 +23,8 @@ public class CreateIndexRequest extends ESHttpRequest<CreateIndexRequest,IESResp
 		setIndex(index);
 //		endpoint; Just do a put to the index url
 		method = "PUT";
+		// some antivirus programs intercept HTTP PUT calls without bodies
+		setBodyJson("{}");
 	}
 
 	/**


### PR DESCRIPTION
HTTP PUT calls without bodies to remote servers are hanging on my machine; I believe this is because they're being intercepted by an anti-virus program. Adding a trivial body prevents this.