### PR TITLE
Support keyword semantics on ES 2

### DIFF
--- a/src/com/winterwell/es/ESType.java
+++ b/src/com/winterwell/es/ESType.java
@@ -97,13 +97,13 @@ public class ESType extends LinkedHashMap<String,Object> {
 	 * @return this
 	 */
 	public ESType text() {
-		put("type", "text");
+		put("type", "string");
 		return this;
 	}
 	
 	public ESType keyword() {
-		put("type", "keyword");
-		return this;
+		put("type", "string");
+		return noAnalyzer();
 	}
 	
 	@Override

--- a/src/com/winterwell/es/client/ESConfig.java
+++ b/src/com/winterwell/es/client/ESConfig.java
@@ -17,7 +17,7 @@ import com.winterwell.utils.time.TUnit;
 public class ESConfig {
 
 	public static final String CLIENT_VERSION = "0.9";
-	public static final String ES_SUPPORTED_VERSION = "5.0";
+	public static final String ES_SUPPORTED_VERSION = "2.4";
 	
 	@Override
 	public String toString() {


### PR DESCRIPTION
ES 2 doesn't support the "keyword" or "text" types, but you can achieve the same effect with the "string" type and the right analyzer settings.