### PR TITLE
Set MIME-type to application/json

### DIFF
--- a/src/com/winterwell/es/client/ESHttpRequest.java
+++ b/src/com/winterwell/es/client/ESHttpRequest.java
@@ -349,7 +349,7 @@ public class ESHttpRequest<SubClass extends ESHttpRequest, ResponseSubClass exte
 				
 				assert JSON.parse(srcJson) != null : srcJson;
 				
-				jsonResult = fb.post(url.toString(), FakeBrowser.MIME_TYPE_URLENCODED_FORM, srcJson);
+				jsonResult = fb.post(url.toString(), "application/json", srcJson);
 								
 			} else {
 				assert body == null : body;


### PR DESCRIPTION
Amazon's ES service wraps Elasticsearch in some kind of proxy, and this proxy objects to using `application/x-www-form-urlencoded` with query-string parameters:

https://github.com/elastic/elasticsearch-ruby/issues/226

Status: untested, because I can't get elasticsearch-java-client to build :'(